### PR TITLE
Remove sqlalchemy as a dependency, and add it to the dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:2.7
 RUN sed '/st_mysql_options options;/a unsigned int reconnect;' /usr/include/mysql/mysql.h -i.bkp
 RUN pip install mysql-python
 RUN pip install PyMySQL
+RUN pip install sqlalchemy==1.4.32
 
 EXPOSE 8082
 ENTRYPOINT [ "luigid" ]

--- a/setup.py
+++ b/setup.py
@@ -40,11 +40,6 @@ with open('README.rst') as fobj:
 install_requires = [
     'tornado>=4.0,<5',
     'python-daemon<3.0',
-    # sqlalchemy is a requirement for writing task records to the Luigi history server.
-    # We could install it in the luigi venvironment, be we just made it a dependency here
-    # instead.
-    # So that we can build documentation for luigi.db_task_history and luigi.contrib.sqla
-    'sqlalchemy==1.4.32',
 ]
 
 if os.environ.get('READTHEDOCS', None) == 'True':


### PR DESCRIPTION
SQLAlchemy is required only by the luigi scheduler, and has a bad transitive dep on greenlet which is breaking foursquare.web in python3.

Remove the dependency from the wheel and add it to the scheduler env via the docker file. 